### PR TITLE
fix(scientific-reflow): Rename causal matrix C to property matrix P

### DIFF
--- a/scientific-reflow/README.md
+++ b/scientific-reflow/README.md
@@ -136,8 +136,8 @@ Determine the crystal structure of an unknown material using X-ray diffraction.
 2. **Transform experimental graph to matrices**:
    - Adjacency matrix A (who connects to whom)
    - Measurement matrix B (observed D→E diffraction pattern)
-   - Causal matrix C (known A, B, C, E properties; unknown D properties)
-3. **Apply SVD-based gap closure**: Solve B = C × A⁻¹ for unknown C elements (System D properties)
+   - Property matrix P (known properties of Systems A, B, C, E; unknown properties of System D)
+3. **Apply SVD-based gap closure**: Solve B = P × A⁻¹ for unknown P elements (System D properties)
 4. **Generate hypothesis**: "Sample is FCC crystal with lattice parameter a=3.92±0.05 Å, space group Fm-3m"
 5. **Validate**: Predict diffraction peak positions at 2θ = 38.5°, 44.7°, 65.1° (Cu Kα) → compare to measured pattern
 

--- a/scientific-reflow/definitions/experimental_scientific_systems_framework.json
+++ b/scientific-reflow/definitions/experimental_scientific_systems_framework.json
@@ -198,8 +198,8 @@
         "use_cases": [
           "Generate adjacency matrix A (who connects to whom)",
           "Generate interaction matrix B (measured observables)",
-          "Generate causal matrix C (causal relationships)",
-          "Solve for unknown properties: B = C × A⁻¹ (matrix gap closure)"
+          "Generate property matrix P (system properties: known for A,B,C,E; unknown for D)",
+          "Solve for unknown properties: B = P × A⁻¹ (matrix gap closure)"
         ],
         "required_fields": ["interaction_strength", "observability"],
         "tool": "tools/reflow_gap_closure.py (integrates matrix_gap_detection.py + link_architectures.py)"
@@ -285,7 +285,7 @@
         "step": 3,
         "name": "Transform DAG to matrices",
         "tool": "tools/reflow_gap_closure.py (internal matrix transformation)",
-        "output": "Adjacency matrix A, Measurement matrix B, Causal matrix C",
+        "output": "Adjacency matrix A, Measurement matrix B, Property matrix P",
         "action": "Automatic - called by reflow_gap_closure.py"
       },
       {
@@ -430,7 +430,7 @@
     },
     "matrix_gap_detection.py": {
       "usage": "Called internally by reflow_gap_closure.py",
-      "function": "Transforms DAG to matrices, applies SVD, solves B = C × A⁻¹ for unknowns"
+      "function": "Transforms DAG to matrices, applies SVD, solves B = P × A⁻¹ for unknowns"
     },
     "link_architectures.py": {
       "usage": "Links functional architecture (WHAT we want to know) to experimental architecture (HOW we measure it)",

--- a/scientific-reflow/docs/QUICK_START.md
+++ b/scientific-reflow/docs/QUICK_START.md
@@ -117,7 +117,7 @@ LLM proceeds to `03-gap_closure_analysis.json`.
 **Matrix transformation**:
 - Adjacency matrix A (5×5): Undulator, DCM, KB, Sample, Detector
 - Measurement matrix B: Sample→Detector diffraction pattern (HIGH observability)
-- Causal matrix C: Known for A, B, C, E; **UNKNOWN for D**
+- Property matrix P: Known properties of Systems A, B, C, E; **UNKNOWN properties of System D**
 
 **Run gap closure**:
 ```bash

--- a/scientific-reflow/test_data/README_NIPS3_VALIDATION.md
+++ b/scientific-reflow/test_data/README_NIPS3_VALIDATION.md
@@ -139,7 +139,7 @@ Compare Scientific Reflow's inferred exciton energy to published value:
 
 1. **Complexity of RIXS**: RIXS involves quantum mechanics (2p→3d transitions, exciton formation). Gap closure must recognize that ΔE=1.47 eV encodes System D electronic properties.
 
-2. **Matrix Formulation**: Need to correctly formulate measurement matrix B (RIXS spectrum) and causal matrix C (sample properties).
+2. **Matrix Formulation**: Need to correctly formulate measurement matrix B (RIXS spectrum) and property matrix P (sample properties).
 
 3. **Realistic Expectations**: We may not perfectly match 1.47 eV. Success is:
    - Identifying an excitation in ~1-2 eV range
@@ -206,7 +206,7 @@ Compare Scientific Reflow's inferred exciton energy to published value:
 **Diagnose**:
 1. Check SVD condition number (ill-conditioned problem?)
 2. Review measurement matrix B (correctly encoded RIXS data?)
-3. Review causal matrix C (sample properties correctly linked to observables?)
+3. Review property matrix P (sample properties correctly linked to observables?)
 4. Check System D→E interaction (observability HIGH? critical_for_gap_closure=TRUE?)
 
 **Fix**:

--- a/scientific-reflow/workflows/03-gap_closure_analysis.json
+++ b/scientific-reflow/workflows/03-gap_closure_analysis.json
@@ -36,21 +36,21 @@
         },
         {
           "action_id": "GC-01-A04",
-          "description": "Generate causal matrix C",
-          "details": "Create causal matrix C encoding KNOWN causal relationships. C[i,j] = interaction_strength if edge i→j has KNOWN properties (Systems A, B, C, E). C[d,j] = UNKNOWN for System D rows.",
-          "output": "Causal matrix C (N×N with unknowns for System D)"
+          "description": "Generate property matrix P",
+          "details": "Create property matrix P encoding KNOWN system properties. P[i,j] = interaction_strength if edge i→j has KNOWN properties (Systems A, B, C, E). P[d,j] = UNKNOWN for System D rows.",
+          "output": "Property matrix P (N×N with unknowns for System D)"
         },
         {
           "action_id": "GC-01-A05",
           "description": "Document matrix transformation",
-          "details": "Create docs/matrix_transformation.md: matrix dimensions, encoding schemes, known vs unknown elements, mathematical formulation (B = C × A or similar)",
+          "details": "Create docs/matrix_transformation.md: matrix dimensions, encoding schemes, known vs unknown elements, mathematical formulation (B = P × A or similar)",
           "output": "docs/matrix_transformation.md"
         }
       ],
       "validation": {
         "blocking": true,
         "criteria": [
-          "Matrices A, B, C generated",
+          "Matrices A, B, P generated",
           "System D elements identified as unknowns",
           "Matrix dimensions consistent",
           "Transformation documented"

--- a/test_systems/nips3_rixs_validation/VALIDATION_SUMMARY.md
+++ b/test_systems/nips3_rixs_validation/VALIDATION_SUMMARY.md
@@ -122,7 +122,7 @@
 4. **Physics-Architecture Coupling**
    - Map architectural interactions (D→E) to physical processes (RIXS scattering)
    - Encode measurement matrix B from spectral data
-   - Solve for unknown properties in causal matrix C
+   - Solve for unknown properties in property matrix P
 
 ---
 

--- a/test_systems/nips3_rixs_validation/docs/gap_closure_analysis.md
+++ b/test_systems/nips3_rixs_validation/docs/gap_closure_analysis.md
@@ -16,14 +16,14 @@ This validation test reveals **CRITICAL INSIGHTS** about Scientific Reflow's cur
 
 ### Conceptual Framework
 
-Scientific Reflow aims to solve: **B = C × A** or **B = C × A⁻¹**
+Scientific Reflow aims to solve: **B = P × A** or **B = P × A⁻¹**
 
 Where:
 - **A** = Adjacency matrix (who connects to whom)
 - **B** = Measurement matrix (observed data)
-- **C** = Causal matrix (system properties, including unknowns)
+- **P** = Property matrix (system properties, including unknowns)
 
-**Goal**: Solve for unknown elements in C (System D properties) given measured B and known A.
+**Goal**: Solve for unknown elements in P (System D properties) given measured B and known A.
 
 ---
 
@@ -98,11 +98,11 @@ Where:
 
 **Matrix B would encode**: Peak position at ΔE = 1.47 eV
 
-### Step 2: Formulate Causal Matrix C (with unknowns)
+### Step 2: Formulate Property Matrix P (with unknowns)
 
-**System D row in C** (NiPS3 properties):
+**System D row in P** (NiPS3 properties):
 ```
-C_D = [... , exciton_energy = ?, Hund_exchange = ?, ...]
+P_D = [... , exciton_energy = ?, Hund_exchange = ?, ...]
 ```
 
 **Known**: Crystal structure, magnetic order, temperature
@@ -118,7 +118,7 @@ Peak_position_in_B ≈ Exciton_energy_in_C
 ```
 
 **SVD would**:
-1. Identify that peak position in RIXS spectrum (B) directly encodes exciton energy (C)
+1. Identify that peak position in RIXS spectrum (B) directly encodes exciton energy (P)
 2. Extract peak position via spectral analysis
 3. Assign exciton energy = peak position ± uncertainty
 


### PR DESCRIPTION
PROBLEM: Naming collision between "System C (Environment)" and "Causal matrix C" caused confusion in documentation and workflows.

SOLUTION: Renamed matrix from C to P (Property matrix) throughout codebase:
- Updated mathematical notation: B = C × A⁻¹ → B = P × A⁻¹
- P clearly indicates "system properties" (known for A,B,C,E; unknown for D)
- Eliminates confusion with System C (Environment)

FILES UPDATED (7 files):
1. scientific-reflow/README.md
2. scientific-reflow/definitions/experimental_scientific_systems_framework.json
3. scientific-reflow/docs/QUICK_START.md
4. scientific-reflow/test_data/README_NIPS3_VALIDATION.md
5. scientific-reflow/workflows/03-gap_closure_analysis.json
6. test_systems/nips3_rixs_validation/VALIDATION_SUMMARY.md
7. test_systems/nips3_rixs_validation/docs/gap_closure_analysis.md

IMPACT: Improved clarity and reduced cognitive load for users working with both the 5-system model (A,B,C,D,E) and matrix gap closure formulation.